### PR TITLE
22 data quality circuits countryid missing

### DIFF
--- a/build_database.ps1
+++ b/build_database.ps1
@@ -297,14 +297,14 @@
 
         if($database)
         {
-            Write-Host "INFO: Performing Data Updates" -ForegroundColor Yellow
-            Invoke-DbaQuery -SqlInstance $svr -Database $databaseName -File ('{0}\src\SequelFormula_data_updates.sql' -f $rootpath)
+            Write-Host "INFO: Running data quality fixes" -ForegroundColor Yellow
+            Invoke-DbaQuery -SqlInstance $svr -Database $databaseName -File ('{0}\src\SequelFormula_data_quality.sql' -f $rootpath)
         } 
 
         if($database)
         {
-            Write-Host "INFO: Running data quality fixes" -ForegroundColor Yellow
-            Invoke-DbaQuery -SqlInstance $svr -Database $databaseName -File ('{0}\src\SequelFormula_data_quality.sql' -f $rootpath)
+            Write-Host "INFO: Performing Data Updates" -ForegroundColor Yellow
+            Invoke-DbaQuery -SqlInstance $svr -Database $databaseName -File ('{0}\src\SequelFormula_data_updates.sql' -f $rootpath)
         } 
 
         if($database)

--- a/src/SequelFormula_data_quality.sql
+++ b/src/SequelFormula_data_quality.sql
@@ -1,1 +1,3 @@
 /* DATA QUALITY FIX */
+
+UPDATE [dbo].[circuits] SET country = 'USA' WHERE country = 'United States'


### PR DESCRIPTION
This pull request resolves issue #22 we have added in some data quality fixes to update **United States** to **USA** which matches the other countries in the data. 

The build script required updating to move the data quality update above the data updates. 

This fix will be available in the Zandvoort release.