### PR TITLE
Testing fixes

### DIFF
--- a/build_database.ps1
+++ b/build_database.ps1
@@ -329,20 +329,21 @@
         catch {
             Write-Error -Message "Unable to export tables to '$tablePath'. Error was: $error" -ErrorAction Stop
             Add-Content -Path $logFullPath -Value "$(Get-Date -f yyyy-MM-dd-HH-mm) - Unable to export tables to '$tablePath'. Error was: $error"
-        }
-
+        }       
         
-        if(Test-Path -Path $backupFullPath)
-        {
-            Write-Host "WARN: Database backup already exists, removing" -ForegroundColor Red
-            Remove-Item -Path $backupFullPath
-        }        
-
         if($backupDatabase -eq $True)
         {
             Write-Host "INFO: Attempting to create a database backup." -ForegroundColor Yellow
+            
+            if(Test-Path -Path $backupFullPath)
+            {
+                Write-Host "WARN: Database backup already exists, removing" -ForegroundColor Red
+                Remove-Item -Path $backupFullPath
+            } 
+                   
             Backup-DbaDatabase -SqlInstance $svr -Database $databaseName -Path $backupLocation -FilePath $backupName -Type Full 
             Write-Host "SUCCESS: Database backup has been completed." -ForegroundColor Green
+
         } else {
             Write-Host "WARN: No backup has been taken as backupDatabase is set to False." -ForegroundColor Red
         }        

--- a/src/SequelFormula_data_updates.sql
+++ b/src/SequelFormula_data_updates.sql
@@ -248,26 +248,33 @@ UPDATE [dbo].[sprintResults] SET time_converted = TRY_CONVERT(time(3),[TimeDiffe
 GO
 
 ALTER TABLE [dbo].[constructors] DROP COLUMN [nationality]; 
+
 ALTER TABLE [dbo].[circuits] DROP COLUMN [location]; 
 ALTER TABLE [dbo].[circuits] DROP COLUMN [country]; 
+
 ALTER TABLE [dbo].[results] DROP COLUMN [positionText];
+ALTER TABLE [dbo].[results] DROP COLUMN [fastestLapTime];
+ALTER TABLE [dbo].[results] DROP COLUMN [fastestLapSpeed];
+
+ALTER TABLE [dbo].[qualifying] DROP COLUMN q1;
+ALTER TABLE [dbo].[qualifying] DROP COLUMN q2;
+ALTER TABLE [dbo].[qualifying] DROP COLUMN q3;
+
+ALTER TABLE [dbo].[results] DROP COLUMN [time];
+ALTER TABLE [dbo].[results] DROP COLUMN [timeDifference];
+
 ALTER TABLE [dbo].[drivers] DROP COLUMN [nationality]; 
-ALTER TABLE [dbo].[sprintResults] DROP COLUMN [positionText];
+
 ALTER TABLE [dbo].[positionText] DROP COLUMN [positionCode];
 ALTER TABLE [dbo].[constructorResults] DROP COLUMN [status];
 ALTER TABLE [dbo].[constructorStandings] DROP COLUMN [positionText];
-ALTER TABLE [dbo].[constructorStandings] DROP COLUMN [positionText];
 ALTER TABLE [dbo].[driverStandings] DROP COLUMN [positionText];
-ALTER TABLE [dbo].[sprintResults] DROP COLUMN [fastestLapTime];
-ALTER TABLE [dbo].[results] DROP COLUMN [fastestLapTime];
-ALTER TABLE [dbo].[results] DROP COLUMN [fastestLapSpeed];
 ALTER TABLE [dbo].[pitStops] DROP COLUMN [duration];
-ALTER TABLE [dbo].[results] DROP COLUMN q1;
-ALTER TABLE [dbo].[results] DROP COLUMN q2;
-ALTER TABLE [dbo].[results] DROP COLUMN q3;
 ALTER TABLE [dbo].[lapTimes] DROP COLUMN [time];
-ALTER TABLE [dbo].[results] DROP COLUMN [time];
-ALTER TABLE [dbo].[results] DROP COLUMN [timeDifference];
+
+ALTER TABLE [dbo].[sprintResults] DROP COLUMN [fastestLapTime];
+ALTER TABLE [dbo].[sprintResults] DROP COLUMN [positionText];
+ALTER TABLE [dbo].[sprintResults] DROP COLUMN [timeDifference];
 ALTER TABLE [dbo].[sprintResults] DROP COLUMN [time];
 
 EXEC sp_rename 'dbo.sprintResults.fastestLapTime_converted', 'fastestLapTime', 'COLUMN';

--- a/src/SequelFormula_tables.sql
+++ b/src/SequelFormula_tables.sql
@@ -302,7 +302,7 @@ CREATE TABLE [dbo].[tempCircuits](
 
 CREATE TABLE [dbo].[driverNumbers]
 (
-	driverNumberID INT NOT NULL IDENTITY(1,1),
+	driverNumberID INT NOT NULL,
 	number INT NOT NULL,
 	driverID INT NOT NULL,
 	constructorID INT,
@@ -312,25 +312,36 @@ CREATE TABLE [dbo].[driverNumbers]
 );
 
 ALTER TABLE [dbo].[driverNumbers] ADD CONSTRAINT PK_driverNumbers_driverNumberID PRIMARY KEY (driverNumberID);
+
 ALTER TABLE [dbo].[Results] ADD positionTextID INT;
+ALTER TABLE [dbo].[results] ADD [timeDifference] DATETIME NULL; 
+ALTER TABLE [dbo].[results] ADD [fastestLapTime_Converted] TIME(3) NULL; 
+ALTER TABLE [dbo].[results] ADD [fastestLapSpeed_Decimal] DECIMAL(18,3) NULL; 
+ALTER TABLE [dbo].[results] ADD time_converted time(3);
+
+
 ALTER TABLE [dbo].[circuits] ADD locationID INT;
 ALTER TABLE [dbo].[circuits] ADD countryID INT;
 ALTER TABLE [dbo].[circuits] ADD circuitDirectionID INT;
 ALTER TABLE [dbo].[circuits] ADD circuitTypeID INT;
+
 ALTER TABLE [dbo].[sprintResults] ADD positionTextID INT;
-ALTER TABLE [dbo].[constructors] ADD nationalityID INT; 
-ALTER TABLE [dbo].[drivers] ADD nationalityID INT;
-ALTER TABLE [dbo].[constructorResults] ADD positionTextID INT;
-ALTER TABLE [dbo].[constructorStandings] ADD positionTextID INT;
-ALTER TABLE [dbo].[constructorStandings] ADD positionTextID INT;
-ALTER TABLE [dbo].[driverStandings] ADD positionTextID INT;
-ALTER TABLE [dbo].[results] ADD [timeDifference] DATETIME NULL; 
+ALTER TABLE [dbo].[sprintResults] ADD time_converted time(3);
 ALTER TABLE [dbo].[sprintResults] ADD [timeDifference] DATETIME NULL; 
 ALTER TABLE [dbo].[sprintResults] ADD [fastestLapTime_converted] TIME(3) NULL; 
-ALTER TABLE [dbo].[results] ADD [fastestLapTime_Converted] TIME(3) NULL; 
-ALTER TABLE [dbo].[results] ADD [fastestLapSpeed_Decimal] DECIMAL(18,3) NULL; 
+
+ALTER TABLE [dbo].[constructors] ADD nationalityID INT; 
+
+ALTER TABLE [dbo].[drivers] ADD nationalityID INT;
+
+ALTER TABLE [dbo].[constructorResults] ADD positionTextID INT;
+
+ALTER TABLE [dbo].[constructorStandings] ADD positionTextID INT;
+
+ALTER TABLE [dbo].[driverStandings] ADD positionTextID INT;
+
 ALTER TABLE [dbo].[pitStops] ADD [duration_converted] DECIMAL(18,3);
-ALTER TABLE [dbo].[qualifying] ADD [q1_converted] TIME(3), [q2_converted] TIME(3), [q3_converted] TIME(3)
+
+ALTER TABLE [dbo].[qualifying] ADD [q1_converted] TIME(3), [q2_converted] TIME(3), [q3_converted] TIME(3);
+
 ALTER TABLE [dbo].[lapTimes] ADD time_converted TIME(3);
-ALTER TABLE [dbo].[results] ADD time_converted time(3);
-ALTER TABLE [dbo].[sprintResults] ADD time_converted time(3);


### PR DESCRIPTION
A number of fixes implemented during testing of recent changes to the database schema. 

- Removed a number of duplicate values carried over from development
- Added in the ability to no longer remove a backup when a backup is not requested to be taken
- Removed identity from the drivers number table 
- Separated the alter statements out into respective tables for ease of reading. 